### PR TITLE
Link rendered version of 'Get started' in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ and the version number:
   # ForestAtRisk version 0.2.
 
 You can also test the package executing the commands in the `Get
-started <notebooks/get_started.html>`__ tutorial.
+started <https://ecology.ghislainv.fr/forestatrisk/notebooks/get_started.html>`__ tutorial.
    
 Main functionalities
 ====================


### PR DESCRIPTION
Most users clicking on a 'Get started' link will be looking to quickly see the
commands they can run. Linking to the rendered version on the package
website instead of the raw html will make this easier for the average user.